### PR TITLE
feat: improve translation cache loading for laravel 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,22 +201,6 @@ php artisan translations:import-files-to-database --locales=en,nl --overwrite
 
 ### FAQ
 <details>
-<summary>Laravel 13 compatibility issue with cache serialization</summary>
-
-Laravel 13 introduced a `serializable_classes` option in the default `config/cache.php` file. When this is set to `false`, the package will not work correctly because the cached translations (which use Eloquent Collections) cannot be serialized properly.
-
-To fix this, update your `config/cache.php` file as follows:
-
-```diff
--'serializable_classes' => false,
-+'serializable_classes' => [
-+    \Illuminate\Database\Eloquent\Collection::class,
-+],
-```
-
-</details>
-
-<details>
 <summary>Installation conflict with [mcamara/laravel-localization](https://github.com/mcamara/laravel-localization)</summary>
 
 The laravel-localization package offers route translation functionality by leveraging Laravel's translator.

--- a/src/Loaders/DatabaseLoader.php
+++ b/src/Loaders/DatabaseLoader.php
@@ -17,7 +17,10 @@ class DatabaseLoader implements TranslationLoaderContract
     public function loadTranslations(string $locale, string $group, ?string $namespace = null): array
     {
         $configuredModel = TranslationLoaderServiceProvider::getConfiguredModel();
-        $translations = $this->translationsCache->remember(fn () => $configuredModel::get());
+        $cachedData = $this->translationsCache->remember(fn () => $configuredModel::get()->toArray());
+        // Handle both new array caches and old Collection caches for backward compatibility
+        $data = is_array($cachedData) ? $cachedData : $cachedData->toArray();
+        $translations = $configuredModel::hydrate($data);
 
         return $translations
             ->where('group', $group)

--- a/tests/Feature/TranslationsCacheTest.php
+++ b/tests/Feature/TranslationsCacheTest.php
@@ -109,4 +109,24 @@ final class TranslationsCacheTest extends TestCase
 
         $this->assertQueryCount(4);
     }
+
+    #[Test]
+    public function it_can_restore_translations_from_old_cached_collection_objects(): void
+    {
+        // Create a database translation with a value
+        Translation::query()->create(['group' => '*', 'key' => 'test-key', 'value_en' => 'Test Value']);
+
+        // Simulate old cached data as a Collection (the old behavior before array caching)
+        // by using remember() which caches and returns the Collection directly
+        $this->translationsCache->remember(fn () => Translation::query()->get());
+
+        // Reset the internal translator cache to force re-fetching from the database cache
+        $this->resetInternalTranslatorCache();
+
+        // Request the translation - this should work even though the cache contains a Collection instead of an array
+        $result = trans('test-key');
+
+        // The translation should still work and return the cached value
+        $this->assertEquals('Test Value', $result);
+    }
 }


### PR DESCRIPTION
Laravel now ships with a `serializable_classes` config value, which requires to append `Illuminate\Database\Eloquent\Collection::class` into the array for this package to work. This PR solves this by storing the data as an array and later hydrating it on the specified model.